### PR TITLE
Alternative to AWS auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,27 @@
 ![Package Version](https://img.shields.io/pypi/v/aws-s3-tools)
 ![Python Version](https://img.shields.io/pypi/pyversions/aws-s3-tools)
 
-AWS S3 Tools is a Python package to make it easier to deal with S3 objects, where you can:
+AWS S3 Tools is a Python package to make it easier to interact with S3 objects, where you can:
 
-- Check if S3 objects exist
 - List S3 bucket content
-- Read from S3 objects to Python variables
-- Write from Python variables to S3 objects
-- Upload from local files to S3
-- Download from S3 to local files
-- Delete S3 objects
-- Move S3 objects
+- Check if an S3 object exists
+- Download/upload S3 objects to/from local files
+- Read/write S3 objects into/from Python variables
+- Delete/Move S3 objects
 
-The AWS authentication is done via boto3 package,
-[click here to know more about it](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).
+The AWS S3 authentication is done via boto3 package, via environment variables, aws config file, or parameters.
+All S3 objects functions, in this package, have the option to set AWS Session authentication by passing the following dictionary on the `aws_auth` parameter, with the schema below (not all field are required).
+To understand more about AWS authentication mechanism, [read boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).
+
+```python
+aws_auth = {
+    'region_name': 'REGION',
+    'aws_access_key_id': 'ACCESS_KEY',
+    'aws_secret_access_key': 'SECRET_KEY',
+    'aws_session_token': 'SESSION_TOKEN',
+    'profile_name': 'PROFILE_NAME'
+}
+```
 
 ---
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,18 +1,26 @@
 Introduction
 ============
 
-AWS S3 Tools is a Python package to make it easier to deal with S3 objects, where you can:
+AWS S3 Tools is a Python package to make it easier to interact with S3 objects, where you can:
 
-- List S3 buckets' content
-- Check if S3 objects exist
-- Read from S3 objects to Python variables
-- Write from Python variables to S3 objects
-- Upload from local files to S3
-- Download from S3 to local files
-- Delete S3 objects
-- Move S3 objects
+- List S3 bucket content
+- Check if an S3 object exists
+- Download/upload S3 objects to/from local files
+- Read/write S3 objects into/from Python variables
+- Delete/Move S3 objects
 
-The AWS authentication is done via boto3 package, `click here <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html>`_.
+The AWS S3 authentication is done via boto3 package, via environment variables, aws config file, or parameters.
+All S3 objects functions, in this package, have the option to set AWS Session authentication by passing the following dictionary on the `aws_auth` parameter, with the schema below (not all field are required).
+To understand more about AWS authentication mechanism, `read boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html>`_.
+
+.. code-block:: python
+    aws_auth = {
+        'region_name': 'REGION',
+        'aws_access_key_id': 'ACCESS_KEY',
+        'aws_secret_access_key': 'SECRET_KEY',
+        'aws_session_token': 'SESSION_TOKEN',
+        'profile_name': 'PROFILE_NAME'
+    }
 
 Installation
 ------------

--- a/s3_tools/objects/check.py
+++ b/s3_tools/objects/check.py
@@ -1,5 +1,6 @@
 """Check objects on S3 bucket."""
 import boto3
+from botocore.exceptions import ClientError
 
 
 def object_exists(bucket: str, key: str) -> bool:
@@ -9,6 +10,7 @@ def object_exists(bucket: str, key: str) -> bool:
     ----------
     bucket : str
         Bucket name where the object is stored.
+
     key : str
         Full key for the object.
 
@@ -16,6 +18,11 @@ def object_exists(bucket: str, key: str) -> bool:
     -------
     bool
         True if the object exists, otherwise False.
+
+    Raises
+    ------
+    Exception
+        Any problem with the request is raised.
 
     Example
     -------
@@ -27,7 +34,10 @@ def object_exists(bucket: str, key: str) -> bool:
 
     try:
         s3.head_object(Bucket=bucket, Key=key)
-    except Exception:
-        return False
+    except Exception as error:
+        if isinstance(error, ClientError) and (error.response["Error"]["Code"] == "404"):
+            return False
+
+        raise error  # Raise anything different from Not Found
 
     return True

--- a/s3_tools/objects/check.py
+++ b/s3_tools/objects/check.py
@@ -1,9 +1,11 @@
 """Check objects on S3 bucket."""
+from typing import Dict
+
 import boto3
 from botocore.exceptions import ClientError
 
 
-def object_exists(bucket: str, key: str) -> bool:
+def object_exists(bucket: str, key: str, aws_auth: Dict[str, str] = {}) -> bool:
     """Check if an object exists for a given bucket and key.
 
     Parameters
@@ -13,6 +15,9 @@ def object_exists(bucket: str, key: str) -> bool:
 
     key : str
         Full key for the object.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -29,7 +34,7 @@ def object_exists(bucket: str, key: str) -> bool:
     >>> object_exists("myBucket", "myFiles/music.mp3")
     True
     """
-    session = boto3.session.Session()
+    session = boto3.session.Session(**aws_auth)
     s3 = session.client("s3")
 
     try:

--- a/s3_tools/objects/delete.py
+++ b/s3_tools/objects/delete.py
@@ -1,5 +1,6 @@
 """Delete objects from S3 bucket."""
 from typing import (
+    Dict,
     List,
     Optional
 )
@@ -9,7 +10,7 @@ import boto3
 from s3_tools.objects.list import list_objects
 
 
-def delete_object(bucket: str, key: str) -> None:
+def delete_object(bucket: str, key: str, aws_auth: Dict[str, str] = {}) -> None:
     """Delete a given object from S3 bucket.
 
     Parameters
@@ -20,17 +21,20 @@ def delete_object(bucket: str, key: str) -> None:
     key: str
         Key for the object that will be deleted.
 
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
+
     Examples
     --------
     >>> delete_object(bucket="myBucket", key="myData/myFile.data")
 
     """
-    session = boto3.session.Session()
+    session = boto3.session.Session(**aws_auth)
     s3 = session.client("s3")
     s3.delete_object(Bucket=bucket, Key=key)
 
 
-def delete_prefix(bucket: str, prefix: str, dry_run: bool = True) -> Optional[List[str]]:
+def delete_prefix(bucket: str, prefix: str, dry_run: bool = True, aws_auth: Dict[str, str] = {}) -> Optional[List[str]]:
     """Delete all objects under the given prefix from S3 bucket.
 
     Parameters
@@ -43,6 +47,9 @@ def delete_prefix(bucket: str, prefix: str, dry_run: bool = True) -> Optional[Li
 
     dry_run: bool
          If True will not delete the objects.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -60,18 +67,18 @@ def delete_prefix(bucket: str, prefix: str, dry_run: bool = True) -> Optional[Li
     >>> delete_prefix(bucket="myBucket", prefix="myData", dry_run=False)
 
     """
-    keys = list_objects(bucket, prefix)
+    keys = list_objects(bucket, prefix, aws_auth)
 
     if dry_run:
         return [key for key in keys]
 
     for key in keys:
-        delete_object(bucket, key)
+        delete_object(bucket, key, aws_auth)
 
     return None
 
 
-def delete_keys(bucket: str, keys: List[str], dry_run: bool = True) -> None:
+def delete_keys(bucket: str, keys: List[str], dry_run: bool = True, aws_auth: Dict[str, str] = {}) -> None:
     """Delete all objects in the keys list from S3 bucket.
 
     Parameters
@@ -85,6 +92,8 @@ def delete_keys(bucket: str, keys: List[str], dry_run: bool = True) -> None:
     dry_run: bool
          If True will not delete the objects.
 
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Examples
     --------
@@ -102,4 +111,4 @@ def delete_keys(bucket: str, keys: List[str], dry_run: bool = True) -> None:
         return
 
     for key in keys:
-        delete_object(bucket, key)
+        delete_object(bucket, key, aws_auth)

--- a/s3_tools/objects/list.py
+++ b/s3_tools/objects/list.py
@@ -1,32 +1,45 @@
 """List S3 bucket objects."""
-from typing import Optional
+from typing import (
+    Dict,
+    Optional,
+    List
+)
 
 import fnmatch
 
 import boto3
 
 
-def list_objects(bucket: str, prefix: str = "", search_str: Optional[str] = None, max_keys: int = 1000) -> list:
+def list_objects(
+    bucket: str,
+    prefix: str = "",
+    search_str: Optional[str] = None,
+    max_keys: int = 1000,
+    aws_auth: Dict[str, str] = {}
+) -> List[str]:
     """Retrieve the list of objects from AWS S3 bucket under a given prefix and search string.
 
     Parameters
     ----------
-        bucket: str
-            AWS S3 bucket where the objects are stored.
+    bucket: str
+        AWS S3 bucket where the objects are stored.
 
-        prefix: str
-            Prefix where the objects are under.
+    prefix: str
+        Prefix where the objects are under.
 
-        search_str: str
-            Basic search string to filter out keys on result (uses Unix shell-style wildcards), by default is None.
-            For more about the search check "fnmatch" package.
+    search_str: str
+        Basic search string to filter out keys on result (uses Unix shell-style wildcards), by default is None.
+        For more about the search check "fnmatch" package.
 
-        max_keys: int
-            Max number of keys to have pagination.
+    max_keys: int
+        Max number of keys to have pagination.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
-    list
+    List[str]
         List of keys inside the bucket, under the path, and filtered.
 
     Examples
@@ -45,9 +58,9 @@ def list_objects(bucket: str, prefix: str = "", search_str: Optional[str] = None
 
     """
     continuation_token: Optional[str] = None
-    keys: list = []
+    keys: List[str] = []
 
-    session = boto3.session.Session()
+    session = boto3.session.Session(**aws_auth)
     s3 = session.client("s3")
 
     while True:

--- a/s3_tools/objects/read.py
+++ b/s3_tools/objects/read.py
@@ -1,11 +1,14 @@
 """Read S3 objects into variables."""
-from typing import Dict
+from typing import (
+    Any,
+    Dict
+)
 
 import boto3
 import ujson
 
 
-def read_object_to_bytes(bucket: str, key: str) -> bytes:
+def read_object_to_bytes(bucket: str, key: str, aws_auth: Dict[str, str] = {}) -> bytes:
     """Retrieve one object from AWS S3 bucket as a byte array.
 
     Parameters
@@ -15,6 +18,9 @@ def read_object_to_bytes(bucket: str, key: str) -> bytes:
 
     key: str
         Key where the object is stored.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -30,14 +36,14 @@ def read_object_to_bytes(bucket: str, key: str) -> bytes:
     b"The file content"
 
     """
-    session = boto3.session.Session()
+    session = boto3.session.Session(**aws_auth)
     s3 = session.client("s3")
     obj = s3.get_object(Bucket=bucket, Key=key)
 
     return obj["Body"].read()
 
 
-def read_object_to_text(bucket: str, key: str) -> str:
+def read_object_to_text(bucket: str, key: str, aws_auth: Dict[str, str] = {}) -> str:
     """Retrieve one object from AWS S3 bucket as a string.
 
     Parameters
@@ -47,6 +53,9 @@ def read_object_to_text(bucket: str, key: str) -> str:
 
     key: str
         Key where the object is stored.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -62,11 +71,11 @@ def read_object_to_text(bucket: str, key: str) -> str:
     "The file content"
 
     """
-    data = read_object_to_bytes(bucket, key)
+    data = read_object_to_bytes(bucket, key, aws_auth)
     return data.decode("utf-8")
 
 
-def read_object_to_dict(bucket: str, key: str) -> Dict:
+def read_object_to_dict(bucket: str, key: str, aws_auth: Dict[str, str] = {}) -> Dict[Any, Any]:
     """Retrieve one object from AWS S3 bucket as a dictionary.
 
     Parameters
@@ -77,9 +86,12 @@ def read_object_to_dict(bucket: str, key: str) -> Dict:
     key: str
         Key where the object is stored.
 
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
+
     Returns
     -------
-    dict
+    Dict[Any, Any]
         Object content as dictionary.
 
     Examples
@@ -91,5 +103,5 @@ def read_object_to_dict(bucket: str, key: str) -> Dict:
     {"key": "value", "1": "text"}
 
     """
-    data = read_object_to_bytes(bucket, key)
+    data = read_object_to_bytes(bucket, key, aws_auth)
     return ujson.loads(data.decode("utf-8"))

--- a/s3_tools/objects/write.py
+++ b/s3_tools/objects/write.py
@@ -5,7 +5,7 @@ from typing import Dict
 import boto3
 
 
-def write_object_from_bytes(bucket: str, key: str, data: bytes) -> str:
+def write_object_from_bytes(bucket: str, key: str, data: bytes, aws_auth: Dict[str, str] = {}) -> str:
     """Upload a bytes object to an object into AWS S3 bucket.
 
     Parameters
@@ -18,6 +18,9 @@ def write_object_from_bytes(bucket: str, key: str, data: bytes) -> str:
 
     data: bytes
         The object data to be uploaded to AWS S3.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -43,13 +46,13 @@ def write_object_from_bytes(bucket: str, key: str, data: bytes) -> str:
     if not isinstance(data, bytes):
         raise TypeError("Object data must be bytes type")
 
-    session = boto3.session.Session()
+    session = boto3.session.Session(**aws_auth)
     s3 = session.client("s3")
     s3.put_object(Bucket=bucket, Key=key, Body=data)
     return "{}/{}/{}".format(s3.meta.endpoint_url, bucket, key)
 
 
-def write_object_from_text(bucket: str, key: str, data: str) -> str:
+def write_object_from_text(bucket: str, key: str, data: str, aws_auth: Dict[str, str] = {}) -> str:
     """Upload a string to an object into AWS S3 bucket.
 
     Parameters
@@ -62,6 +65,9 @@ def write_object_from_text(bucket: str, key: str, data: str) -> str:
 
     data: str
         The object data to be uploaded to AWS S3.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -87,10 +93,10 @@ def write_object_from_text(bucket: str, key: str, data: str) -> str:
     if not isinstance(data, str):
         raise TypeError("Object data must be string type")
 
-    return write_object_from_bytes(bucket, key, data.encode())
+    return write_object_from_bytes(bucket, key, data.encode(), aws_auth)
 
 
-def write_object_from_dict(bucket: str, key: str, data: Dict) -> str:
+def write_object_from_dict(bucket: str, key: str, data: Dict, aws_auth: Dict[str, str] = {}) -> str:
     """Upload a dictionary to an object into AWS S3 bucket.
 
     Parameters
@@ -103,6 +109,9 @@ def write_object_from_dict(bucket: str, key: str, data: Dict) -> str:
 
     data: dict
         The object data to be uploaded to AWS S3.
+
+    aws_auth: Dict[str, str]
+        Contains AWS credentials, by default is empty.
 
     Returns
     -------
@@ -128,4 +137,4 @@ def write_object_from_dict(bucket: str, key: str, data: Dict) -> str:
     if not isinstance(data, dict):
         raise TypeError("Object data must be dictionary type")
 
-    return write_object_from_bytes(bucket, key, json.dumps(data).encode())
+    return write_object_from_bytes(bucket, key, json.dumps(data).encode(), aws_auth)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,6 +17,7 @@ EMPTY_FILE = "tests/resources/empty.data"
 
 @pytest.fixture(scope="module")
 def aws_credentials():
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
     os.environ["AWS_ACCESS_KEY_ID"] = "test"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
     os.environ["AWS_SECURITY_TOKEN"] = "test"
@@ -27,7 +28,7 @@ def aws_credentials():
 def s3_client(aws_credentials):
     with mock_s3():
         session = boto3.session.Session()
-        s3 = session.client("s3", region_name="us-east-1")
+        s3 = session.client("s3")
         yield s3
 
 

--- a/tests/unit/objects/test_check.py
+++ b/tests/unit/objects/test_check.py
@@ -1,4 +1,7 @@
 """Unit tests for check.py"""
+import pytest
+from botocore.exceptions import ClientError
+
 from s3_tools import object_exists
 
 from tests.unit.conftest import (
@@ -8,10 +11,11 @@ from tests.unit.conftest import (
 )
 
 
-class TestUtils:
+class TestCheck:
 
     def test_check_nonexisting_bucket(self, s3_client):
-        assert object_exists(BUCKET_NAME, "prefix/key.csv") is False
+        with pytest.raises(ClientError):
+            object_exists(BUCKET_NAME, "prefix/key.csv")
 
     def test_check_nonexisting_object(self, s3_client):
         with create_bucket(s3_client, BUCKET_NAME):


### PR DESCRIPTION
This PR adds to all functions an `aws_auth` parameter to be used on boto3 Sessions and enabling to have AWS auth via code instead of only env vars or config files.

It also improves the return for the `object_exists` functions to return False only with code 404 is found. Other client errors will be raised.